### PR TITLE
Add more rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.DS_Store
+.nyc_output
+coverage
 node_modules

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
 exports.plugins = [
-  [require('remark-lint-appropriate-heading')]
+  require('remark-lint-appropriate-heading'),
+  require('./rules/file-stem'),
+  require('./rules/file-extension'),
+  require('./rules/require-file-extension')
 ]

--- a/package.json
+++ b/package.json
@@ -3,17 +3,35 @@
   "version": "1.0.2",
   "description": "",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "dependencies": {
-    "remark-lint-appropriate-heading": "^2.0.2"
-  },
   "coordinates": [
     52.5006656,
     13.4193688
-  ]
+  ],
+  "dependencies": {
+    "remark-lint-appropriate-heading": "^2.0.2",
+    "unified-lint-rule": "^1.0.2"
+  },
+  "devDependencies": {
+    "nyc": "^11.3.0",
+    "remark": "^8.0.0",
+    "remark-lint": "^6.0.1",
+    "standard": "^10.0.3",
+    "tape": "^4.8.0",
+    "vfile": "^2.2.0"
+  },
+  "scripts": {
+    "lint": "standard",
+    "test-api": "node test",
+    "test-coverage": "nyc --reporter lcov tape test.js",
+    "test": "npm run lint && npm run test-coverage"
+  },
+  "nyc": {
+    "check-coverage": true,
+    "lines": 100,
+    "functions": 100,
+    "branches": 100
+  }
 }

--- a/rules/file-extension.js
+++ b/rules/file-extension.js
@@ -1,0 +1,13 @@
+var rule = require('unified-lint-rule')
+
+module.exports = rule('standard-readme:file-extension', fileExtension)
+
+var expected = 'md'
+
+function fileExtension (ast, file) {
+  var actual = file.extname ? file.extname.slice(1) : ''
+
+  if (actual && actual !== expected) {
+    file.message('Expected `' + expected + '` instead of `' + actual + '` as extension')
+  }
+}

--- a/rules/file-stem.js
+++ b/rules/file-stem.js
@@ -1,0 +1,13 @@
+var rule = require('unified-lint-rule')
+
+module.exports = rule('standard-readme:file-stem', fileStem)
+
+var expected = 'README'
+
+function fileStem (ast, file) {
+  var actual = file.stem.split('.')[0]
+
+  if (actual !== expected) {
+    file.message('Expected `' + expected + '` instead of `' + actual + '` as file name')
+  }
+}

--- a/rules/require-file-extension.js
+++ b/rules/require-file-extension.js
@@ -1,0 +1,9 @@
+var rule = require('unified-lint-rule')
+
+module.exports = rule('standard-readme:require-file-extension', requireFileExtension)
+
+function requireFileExtension (ast, file) {
+  if (file.extname === '') {
+    file.message('Expected file extension')
+  }
+}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,125 @@
+var test = require('tape')
+var remark = require('remark')
+var vfile = require('vfile')
+var lint = require('remark-lint')
+var fileStem = require('./rules/file-stem')
+var fileExtension = require('./rules/file-extension')
+var requireFileExtension = require('./rules/require-file-extension')
+
+test('standard-readme', function (t) {
+  t.test('file-stem', function (st) {
+    var processor = remark().use(lint).use(fileStem)
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/README.md'})).messages.map(String),
+      [],
+      'ok for `README.md`'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/README.mkd'})).messages.map(String),
+      [],
+      'ok for `README.mkd`'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/README.de.md'})).messages.map(String),
+      [],
+      'ok for `README.de.md`, an internationalized README with a language tag'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/README.nl-BE.md'})).messages.map(String),
+      [],
+      'ok for `README.nl-BE.md`, an internationalized README with a language tag and region tag'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/readme.md'})).messages.map(String),
+      ['~/readme.md:1:1: Expected `README` instead of `readme` as file name'],
+      'not ok for `readme.md`'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/CONTRIBUTING.md'})).messages.map(String),
+      ['~/CONTRIBUTING.md:1:1: Expected `README` instead of `CONTRIBUTING` as file name'],
+      'not ok for `CONTRIBUTING.md`'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/readme.de.md'})).messages.map(String),
+      ['~/readme.de.md:1:1: Expected `README` instead of `readme` as file name'],
+      'not ok for `readme.de.md`, an internationalized README with a language tag'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/readme.nl-BE.md'})).messages.map(String),
+      ['~/readme.nl-BE.md:1:1: Expected `README` instead of `readme` as file name'],
+      'not ok for `readme.nl-BE.md`, an internationalized README with a language tag and region tag'
+    )
+
+    st.end()
+  })
+
+  t.test('file-extension', function (st) {
+    var processor = remark().use(lint).use(fileExtension)
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/README.md'})).messages.map(String),
+      [],
+      'ok for `README.md`'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/README'})).messages.map(String),
+      [],
+      'ok for `README`'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/contributing.md'})).messages.map(String),
+      [],
+      'ok for `contributing.md`'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/readme.mkd'})).messages.map(String),
+      ['~/readme.mkd:1:1: Expected `md` instead of `mkd` as extension'],
+      'not ok for `readme.mkd`'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/README.markdown'})).messages.map(String),
+      ['~/README.markdown:1:1: Expected `md` instead of `markdown` as extension'],
+      'not ok for `README.markdown`'
+    )
+
+    st.end()
+  })
+
+  t.test('require-file-extension', function (st) {
+    var processor = remark().use(lint).use(requireFileExtension)
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/README.md'})).messages.map(String),
+      [],
+      'ok for `README.md`'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/contributing.mkd'})).messages.map(String),
+      [],
+      'ok for `contributing.mkd`'
+    )
+
+    st.deepEqual(
+      processor.processSync(vfile({path: '~/README'})).messages.map(String),
+      ['~/README:1:1: Expected file extension'],
+      'not ok for `README`'
+    )
+
+    st.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
*   `file-stem` — Checks a file is named `README`
*   `file-extension` — Checks a file’s extension is `md`
*   `require-file-extension` — Checks if a file extension exists

Additionally, set up linting (standard), tests (tape), and coverage reporting (nyc).
