### PR TITLE
[require sections] Sections must not be empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "github-slugger": "^1.2.0",
     "mdast-util-to-string": "^1.0.4",
-    "remark-lint-appropriate-heading": "^2.0.2",
+    "remark-lint-appropriate-heading": "projectlint/remark-lint-appropriate-heading",
     "unified-lint-rule": "^1.0.2",
     "unist-util-position": "^3.0.0",
     "unist-util-stringify-position": "^1.1.1"

--- a/rules/require-sections.js
+++ b/rules/require-sections.js
@@ -34,12 +34,14 @@ function requireSections (ast, file, options) {
     required.push('install', 'usage')
   }
 
-  sections = sections.map(id)
   required.forEach(check)
 
   function check (slug) {
-    if (sections.indexOf(slug) === -1) {
+    const section = sections.find(findSlug, slug)
+    if (!section) {
       file.message('Missing required `' + pretty[slug] + '` section')
+    } else if (!section.paragraph) {
+      file.message('`' + pretty[slug] + '` section is empty')
     }
   }
 }
@@ -63,6 +65,6 @@ function inferToc (tree, sections) {
   return lines > maxLinesWithoutTableOfContents
 }
 
-function id (info) {
-  return info.id
+function findSlug (info) {
+  return info.id === this.toString()
 }

--- a/test.js
+++ b/test.js
@@ -341,6 +341,22 @@ test('standard-readme', function (t) {
     )
 
     st.deepEqual(
+      processor.processSync(vfile({
+        path: '~/README.md',
+        contents: [
+          'Example of an OK readme.',
+          '',
+          '## Contributing',
+          '## License',
+          '',
+          'SPDX © Some One'
+        ].join('\n')
+      })).messages.map(String),
+      ['~/README.md:1:1: `Contributing` section is empty'],
+      'not ok for empty `contributing` section'
+    )
+
+    st.deepEqual(
       remark()
         .use(lint)
         .use(requireSections, { toc: true })

--- a/test.js
+++ b/test.js
@@ -618,7 +618,7 @@ test('standard-readme', function (t) {
         '~/README.md:11:1-11:9: Expected `usage` before `license` (1:1-1:11)',
         '~/README.md:13:1-13:7: Expected `api` before `license` (1:1-1:11)',
         '~/README.md:15:1-15:15: Expected `maintainers` before `license` (1:1-1:11)',
-        '~/README.md:17:1-17:14: Expected `contributing` before `license` (1:1-1:11)'
+        '~/README.md:17:1-17:16: Expected `contributing` before `license` (1:1-1:11)'
       ],
       'not ok for a section moved entirely upwards'
     )
@@ -665,7 +665,7 @@ test('standard-readme', function (t) {
         '~/README.md:9:1-9:9: Expected `usage` before `license` (1:1-1:11)',
         '~/README.md:7:1-7:7: Expected `api` before `license` (1:1-1:11)',
         '~/README.md:5:1-5:15: Expected `maintainers` before `license` (1:1-1:11)',
-        '~/README.md:3:1-3:14: Expected `contributing` before `license` (1:1-1:11)'
+        '~/README.md:3:1-3:16: Expected `contributing` before `license` (1:1-1:11)'
       ],
       'not ok for all sections inverted'
     )

--- a/util/schema.js
+++ b/util/schema.js
@@ -13,15 +13,31 @@ function schema (tree) {
   slugs.reset()
 
   /* Get all headings of level 2 and use slugs as IDs for each heading. */
+  let getParagraph
+
   while (++index < length) {
     node = children[index]
 
-    if (node.type === 'heading' && node.depth === 2) {
-      map.push({
-        id: slugs.slug(toString(node)),
-        node: node
-      })
+    switch (node.type) {
+      case 'heading':
+        if (node.depth !== 2) break
+
+        map.push({
+          id: slugs.slug(toString(node)),
+          node: node
+        })
+
+        getParagraph = true
+        continue
+
+      case 'paragraph':
+        if (getParagraph) {
+          map[map.length - 1].paragraph = node
+        }
+        break
     }
+
+    getParagraph = false
   }
 
   return map


### PR DESCRIPTION
This pull-request checks that sections are not empty, but instead they have some content, fixing #28. It also fix two previously failling tests.

There's a commit changuing `remark-lint-appropriate-heading` dependency to a personal fork, when https://github.com/RichardLitt/remark-lint-appropriate-heading/pull/8 get merged and published we can change it back.