### PR TITLE
Enhance empty section check not to fail on ToC

### DIFF
--- a/rules/require-sections.js
+++ b/rules/require-sections.js
@@ -40,7 +40,7 @@ function requireSections (ast, file, options) {
     const section = sections.find(findSlug, slug)
     if (!section) {
       file.message('Missing required `' + pretty[slug] + '` section')
-    } else if (!section.paragraph) {
+    } else if (section.isEmpty) {
       file.message('`' + pretty[slug] + '` section is empty')
     }
   }

--- a/test.js
+++ b/test.js
@@ -357,6 +357,23 @@ test('standard-readme', function (t) {
     )
 
     st.deepEqual(
+      processor.processSync(vfile({
+        path: '~/README.md',
+        contents: [
+          'Example of an OK readme.',
+          '',
+          '## Contributing',
+          '',
+          'Something something.',
+          '',
+          '## License'
+        ].join('\n')
+      })).messages.map(String),
+      ['~/README.md:1:1: `License` section is empty'],
+      'not ok for empty `license` section at end of file (coverage)'
+    )
+
+    st.deepEqual(
       remark()
         .use(lint)
         .use(requireSections, { toc: true })
@@ -490,6 +507,57 @@ test('standard-readme', function (t) {
         })).messages.map(String),
       [],
       'the lines used for the table of contents itself are ignored'
+    )
+
+    st.deepEqual(
+      remark()
+        .use(lint)
+        .use(requireSections, { toc: true })
+        .processSync(vfile({
+          path: '~/README.md',
+          contents: [
+            'Example of an OK readme.',
+            '',
+            '## Table of Contents',
+            '',
+            '## Contributing',
+            '',
+            'Something something.',
+            '',
+            '## License',
+            '',
+            'SPDX © Some One'
+          ].join('\n')
+        })).messages.map(String),
+      ['~/README.md:1:1: `Table of Contents` section is empty'],
+      'not ok for empty `table-of-contents` section'
+    )
+
+    st.deepEqual(
+      remark()
+        .use(lint)
+        .use(requireSections, { toc: true })
+        .processSync(vfile({
+          path: '~/README.md',
+          contents: [
+            'Example of an OK readme.',
+            '',
+            '## Table of Contents',
+            '',
+            '- [Contributing](#contributing)',
+            '- [License](#license)',
+            '',
+            '## Contributing',
+            '',
+            'Something something.',
+            '',
+            '## License',
+            '',
+            'SPDX © Some One'
+          ].join('\n')
+        })).messages.map(String),
+      [],
+      'ok for `table-of-contents` section with list items only'
     )
 
     st.deepEqual(

--- a/util/schema.js
+++ b/util/schema.js
@@ -9,35 +9,34 @@ function schema (tree) {
   var length = children.length
   var index = -1
   var node
+  var nextNode
 
   slugs.reset()
 
   /* Get all headings of level 2 and use slugs as IDs for each heading. */
-  let getParagraph
-
   while (++index < length) {
     node = children[index]
 
-    switch (node.type) {
-      case 'heading':
-        if (node.depth !== 2) break
+    if (node.type === 'heading' && node.depth === 2) {
+      map.push({
+        id: slugs.slug(toString(node)),
+        node: node,
+        isEmpty: false
+      })
 
-        map.push({
-          id: slugs.slug(toString(node)),
-          node: node
-        })
+      if (index + 1 < length) {
+        nextNode = children[index + 1]
 
-        getParagraph = true
-        continue
-
-      case 'paragraph':
-        if (getParagraph) {
-          map[map.length - 1].paragraph = node
+        // If the next node is a header level 2, this section is empty
+        if (nextNode.type === 'heading' && nextNode.depth === 2) {
+          map[map.length - 1].isEmpty = true
         }
-        break
+      } else {
+        // If there is no next node, this section is right before the end of the
+        // document, and also empty
+        map[map.length - 1].isEmpty = true
+      }
     }
-
-    getParagraph = false
   }
 
   return map


### PR DESCRIPTION
# Pull Request

## Description of Changes

- Fixed a bug where the Table of Contents was being flagged as not having any content, due to the code only looking for the presense of `paragraph` elements.